### PR TITLE
Bugfixes and README corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp
 dist
 *.tgz
 coverage/
+.vscode/

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,4 @@ __tests__
 *.test.js
 coverage
 Makefile
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## v1.3.1
+
+**Bugfixes:**
+
+- Fix [No wildcard(s) support for `!=` operator](https://github.com/massfords/ts-rsql-query/issues/6).
+- Fixed a bug where `RsqlOperatorPluginToSqlOptions.keywordsLowerCase` was not passed to the options when it would be configured to `true`.
+- Corrected implementation examples for plugin section in (./README.md#plugins).
+
+**Internals:**
+
+- Added some bugfix related (non-)equality tests to live-DB.
+- Git- and npm-ignored `.vscode/` folder.
+- Fixed internal function `toSqlOperator` to return SQL `=` for RSQL `==` operator (actually, case was never used before, but now it is used and fixed therefore).
+- Added some bugfix related (non-)equality tests to live-DB.
+
 ## v1.3.0
 
 **New feature implementations:**

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ const sql = assembleFullQuery(
     sort: parsedSorts,
     keyset,
   },
-  context
+  context,
 );
 if (sql.isValid) {
   const rows = await db.manyOrNone(sql.sql, context.values);
@@ -242,7 +242,7 @@ const context: SqlContext = {
 
 ### Plugin implementation
 
-The following codes shows an example of how to implement a plugin by the predefined plugin `MapInToEqualsAnyPlugin`:
+The following codes shows an example of how to implement a plugin by the predefined plugin `IsNullPlugin`:
 
 ```typescript
 import { CustomOperator, formatKeyword, isBooleanValueInvariant, RsqlOperatorPlugin, RsqlOperatorPluginToSqlOptions } from "ts-rsql-query";
@@ -259,10 +259,11 @@ export const IsNullPlugin: RsqlOperatorPlugin = {
   invariant: isBooleanValueInvariant,
   toSql: (options: RsqlOperatorPluginToSqlOptions): string => {
     const {
+      keywordsLowerCase,
       selector,
       ast: { operands },
     } = options;
-    return `${selector} ${formatKeyword("IS", options)}${operands?.[0] === "false" ? ` ${formatKeyword("NOT", options)}` : ""} null`;
+    return `${selector} ${formatKeyword("IS", options)}${operands?.[0] === "false" ? ` ${formatKeyword("NOT", keywordsLowerCase)}` : ""} null`;
   },
 };
 ```
@@ -292,9 +293,9 @@ export const MapInToEqualsAnyPlugin: RsqlOperatorPlugin = {
     invariant(ast.operands);
   },
   toSql: (options: RsqlOperatorPluginToSqlOptions): string => {
-    const { ast, selector, values, config } = options;
+    const { ast, keywordsLowerCase, selector, values, config } = options;
     values.push(formatValue({ ast, allowArray: true }, config));
-    return `${selector} = ${formatKeyword("ANY", options)}($${values.length})`;
+    return `${selector} = ${formatKeyword("ANY", keywordsLowerCase)}($${values.length})`;
   },
 };
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -2493,9 +2493,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -8174,9 +8174,9 @@
       "dev": true
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-rsql-query",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-rsql-query",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0",

--- a/src/context.ts
+++ b/src/context.ts
@@ -78,7 +78,7 @@ export type RsqlOperatorPluginToSqlOptions = {
    *
    * @default false
    */
-  readonly keywordsLowerCase?: boolean;
+  readonly keywordsLowerCase?: true | undefined;
   /**
    * The static query configuration.
    */

--- a/src/llb/operators.ts
+++ b/src/llb/operators.ts
@@ -21,6 +21,7 @@ export type KnownOperator = SymbolicOperator | NamedOperator;
  *
  * > NOTE:
  * > - Option `keywordsLowerCase` has no effect for:
+ * >   - `==`
  * >   - `!=`
  * >   - `<`
  * >   - `=lt=`
@@ -31,7 +32,6 @@ export type KnownOperator = SymbolicOperator | NamedOperator;
  * >   - `>=`
  * >   - `=ge=`
  * > - Option `detachedOperators` has no effect for:
- * >   - `==`
  * >   - `=in=`
  * >   - `=out=`
  *
@@ -48,7 +48,7 @@ export const toSqlOperator = (
   const space = detachedOperators ? " " : "";
   switch (operator) {
     case "==":
-      return formatKeyword("LIKE", keywordsLowerCase);
+      return `${space}=${space}`;
     case "!=":
       return `${space}<>${space}`;
     case "<":

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -38,7 +38,7 @@ export const maybeExecuteRsqlOperatorPlugin = (
   ast: ComparisonNode,
   formattedSelector: string,
 ): string | undefined => {
-  const { plugins, values } = context;
+  const { keywordsLowerCase, plugins, values } = context;
   /* Check for plugin (custom operator or overwrite of known operator). */
   const plugin = plugins?.length
     ? plugins.find((plugin) => plugin.operator.toLowerCase() === ast.operator)
@@ -60,6 +60,7 @@ export const maybeExecuteRsqlOperatorPlugin = (
       selector: formattedSelector,
       ast,
       values,
+      keywordsLowerCase,
       config: context,
     });
   }

--- a/src/tests/live-db.it.ts
+++ b/src/tests/live-db.it.ts
@@ -1,20 +1,20 @@
 import {
+  PostgreSqlContainer,
+  StartedPostgreSqlContainer,
+} from "testcontainers";
+import invariant from "tiny-invariant";
+import { parseSort, SortNode } from "ts-rsql";
+import type { SqlContext } from "../context";
+import { lastRowToKeySet, toKeySet } from "../keyset";
+import { assembleFullQuery } from "../query";
+import { TestQueryConfig, TestQueryConfigWithPlugins } from "./fixture";
+import {
   db,
   destroyDb,
   idForTestRecord,
   initDb,
   UserRecord,
 } from "./fixture-db";
-import invariant from "tiny-invariant";
-import { TestQueryConfig, TestQueryConfigWithPlugins } from "./fixture";
-import type { SqlContext } from "../context";
-import { assembleFullQuery } from "../query";
-import { lastRowToKeySet, toKeySet } from "../keyset";
-import { parseSort, SortNode } from "ts-rsql";
-import {
-  PostgreSqlContainer,
-  StartedPostgreSqlContainer,
-} from "testcontainers";
 
 describe("runs the sql with a real db connection", () => {
   let startedContainer: StartedPostgreSqlContainer | null = null;
@@ -39,6 +39,34 @@ describe("runs the sql with a real db connection", () => {
       {
         filter: "firstName==Alice",
         rows: 1,
+      },
+      {
+        filter: "firstName==*Alice",
+        rows: 1,
+      },
+      {
+        filter: "firstName==Alice*",
+        rows: 1,
+      },
+      {
+        filter: "firstName==*Alice*",
+        rows: 1,
+      },
+      {
+        filter: "firstName!=Alice",
+        rows: 2,
+      },
+      {
+        filter: "firstName!=*Alice",
+        rows: 2,
+      },
+      {
+        filter: "firstName!=Alice*",
+        rows: 2,
+      },
+      {
+        filter: "firstName!=*Alice*",
+        rows: 2,
       },
       {
         filter: "firstName==Alice,firstName==Bo*",

--- a/src/tests/operators.test.ts
+++ b/src/tests/operators.test.ts
@@ -12,7 +12,7 @@ describe("operators tests", () => {
     }> = [
       {
         rsql: "==",
-        sql: "LIKE",
+        sql: "=",
       },
       {
         rsql: "!=",
@@ -71,7 +71,7 @@ describe("operators tests", () => {
     }> = [
       {
         rsql: "==",
-        sql: "like",
+        sql: " = ",
       },
       {
         rsql: "!=",

--- a/src/tests/plugin.test.ts
+++ b/src/tests/plugin.test.ts
@@ -83,6 +83,28 @@ describe("tests for sql generation by plugins", () => {
       });
     });
 
+    it("should pass the keywordsLowerCase configuration from context", () => {
+      const newContext = {
+        ...context,
+        keywordsLowerCase: true,
+      } as unknown as SqlContext;
+      expect(
+        maybeExecuteRsqlOperatorPlugin(newContext, ast, formattedSelector),
+      ).toBe(sql);
+
+      expect(mockInvariant).toHaveBeenCalledTimes(1);
+      expect(mockInvariant).toHaveBeenCalledWith(ast);
+
+      expect(mockToSql).toHaveBeenCalledTimes(1);
+      expect(mockToSql).toHaveBeenCalledWith({
+        selector: formattedSelector,
+        ast,
+        values,
+        keywordsLowerCase: true,
+        config: newContext,
+      });
+    });
+
     it("should return undefined if plugins configuration is empty array", () => {
       expect(
         maybeExecuteRsqlOperatorPlugin(

--- a/src/tests/to-sql.test.ts
+++ b/src/tests/to-sql.test.ts
@@ -3,9 +3,9 @@ jest.mock("../plugin", () => ({
   maybeExecuteRsqlOperatorPlugin: mockMaybeExecuteRsqlOperatorPlugin,
 }));
 
-import { formatKeyword, toSql } from "../llb/to-sql";
 import { parseRsql } from "ts-rsql";
 import type { SqlContext, Value } from "../context";
+import { formatKeyword, toSql } from "../llb/to-sql";
 import { TestQueryConfig } from "./fixture";
 
 describe("tests for sql generation", () => {
@@ -66,6 +66,21 @@ describe("tests for sql generation", () => {
     {
       filter: `name==*Bill*`,
       sql: `name ILIKE $1`,
+      values: ["%Bill%"],
+    },
+    {
+      filter: `name!=Bill*`,
+      sql: `name NOT ILIKE $1`,
+      values: ["Bill%"],
+    },
+    {
+      filter: `name!=*Bill`,
+      sql: `name NOT ILIKE $1`,
+      values: ["%Bill"],
+    },
+    {
+      filter: `name!=*Bill*`,
+      sql: `name NOT ILIKE $1`,
       values: ["%Bill%"],
     },
   ];
@@ -130,6 +145,21 @@ describe("tests for sql generation", () => {
     {
       filter: `name==*Bill*`,
       sql: `name ILIKE $1`,
+      values: ["%Bill%"],
+    },
+    {
+      filter: `name!=Bill*`,
+      sql: `name NOT ILIKE $1`,
+      values: ["Bill%"],
+    },
+    {
+      filter: `name!=*Bill`,
+      sql: `name NOT ILIKE $1`,
+      values: ["%Bill"],
+    },
+    {
+      filter: `name!=*Bill*`,
+      sql: `name NOT ILIKE $1`,
       values: ["%Bill%"],
     },
   ];


### PR DESCRIPTION
**Bugfixes:**

- Fix [No wildcard(s) support for `!=` operator](https://github.com/massfords/ts-rsql-query/issues/6).
- Fixed a bug where `RsqlOperatorPluginToSqlOptions.keywordsLowerCase` was not passed to the options when it would be configured to `true`.
- Corrected implementation examples for plugin section in (./README.md#plugins).

**Internals:**

- Added some bugfix related (non-)equality tests to live-DB.
- Git- and npm-ignored `.vscode/` folder.
- Fixed internal function `toSqlOperator` to return SQL `=` for RSQL `==` operator (actually, case was never used before, but now it is used and fixed therefore).
- Added some bugfix related (non-)equality tests to live-DB.