### PR TITLE
Fix configuration checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## v1.3.1
+## v1.3.3
+
+**Bugfixes:**
+
+- Fix [Optional "boolean" configuration options checked by key-in-object could resolve to true if the key is set to undefined](https://github.com/massfords/ts-rsql-query/issues/8).
+
+## v1.3.2
 
 **Bugfixes:**
 
@@ -14,6 +20,12 @@
 - Git- and npm-ignored `.vscode/` folder.
 - Fixed internal function `toSqlOperator` to return SQL `=` for RSQL `==` operator (actually, case was never used before, but now it is used and fixed therefore).
 - Added some bugfix related (non-)equality tests to live-DB.
+
+## v1.3.1
+
+**Internals:**
+
+- Update ``to`node-version: 20.x`.
 
 ## v1.3.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ts-rsql-query",
-  "version": "1.3.1",
+  "version": "1.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ts-rsql-query",
-      "version": "1.3.1",
+      "version": "1.3.3",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-rsql-query",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Transforms the AST from ts-rsql into a SQL query",
   "main": "./dist/index.js",
   "scripts": {

--- a/src/llb/to-sql.ts
+++ b/src/llb/to-sql.ts
@@ -35,7 +35,7 @@ export const formatSelector = (
   context: SqlContext,
   selector: string,
 ): string => {
-  if (!("selectors" in context)) {
+  if (!context.selectors) {
     return selector;
   }
   const sel = context.selectors[selector];
@@ -71,7 +71,7 @@ export const formatValue = (
   const selConfig = selectorConfig(ast.selector, config);
 
   // case where the config is an enum
-  if (selConfig && "enum" in selConfig) {
+  if (selConfig?.enum) {
     if (allowArray) {
       return (
         ast.operands?.filter((op) => selConfig.enum?.find((e) => e === op)) ??

--- a/src/llb/validate.ts
+++ b/src/llb/validate.ts
@@ -1,9 +1,9 @@
-import type { ASTNode } from "ts-rsql";
-import type { SelectorConfig, SqlContext } from "../context";
-import { isKnownOperator, isPluginOperator } from "./operators";
-import { isAstNode, isComparisonNode } from "./ast";
 import { parseISO } from "date-fns";
 import invariant from "tiny-invariant";
+import type { ASTNode } from "ts-rsql";
+import type { SelectorConfig, SqlContext } from "../context";
+import { isAstNode, isComparisonNode } from "./ast";
+import { isKnownOperator, isPluginOperator } from "./operators";
 
 export const validate = (
   ast: ASTNode,
@@ -66,7 +66,7 @@ export const validate = (
         err: `missing value for selector: ${JSON.stringify(ast.selector)}`,
       };
     }
-    if (!("lax" in context)) {
+    if (!context.lax) {
       const selector = context.selectors[ast.selector];
       if (!selector) {
         return {
@@ -76,7 +76,7 @@ export const validate = (
       }
       if (typeof selector === "object") {
         if (!isValueValid(selector, value)) {
-          if ("enum" in selector) {
+          if (selector.enum) {
             return {
               isValid: false,
               err: `bad selector value for "${
@@ -99,7 +99,7 @@ export const validate = (
 };
 
 const isValueValid = (selector: SelectorConfig, val: string): boolean => {
-  if ("enum" in selector) {
+  if (selector.enum) {
     return selector.enum.some((allowedValue) => val == allowedValue);
   }
   if (!selector.type) {

--- a/src/tests/validate.test.ts
+++ b/src/tests/validate.test.ts
@@ -16,6 +16,14 @@ describe("validate AST tests", () => {
       rsql: "tier==DIAMOND",
       err: `bad selector value for "tier": "DIAMOND" must be one of ["GOLD","SILVER","BRONZE"]`,
     },
+    {
+      rsql: "points=gt=not-an-int",
+      err: 'bad selector value for "points": "not-an-int" is not a integer',
+    },
+    {
+      rsql: "birthday=gt=not-a-date;birthday<not-a-date",
+      err: 'bad selector value for "birthday": "not-a-date" is not a date',
+    },
   ];
   it.each(inputs)("$rsql", ({ rsql, err }) => {
     expect.hasAssertions();
@@ -23,6 +31,41 @@ describe("validate AST tests", () => {
     const actual = toSql(ast, {
       ...TestQueryConfig,
       values: [],
+    });
+    expect(actual).toStrictEqual({ isValid: false, err });
+  });
+
+  /* Test the edge case related to https://github.com/massfords/ts-rsql-query/issues/8 */
+  const inputsForLaxUndefinedCase: Array<{ rsql: string; err: string }> = [
+    {
+      rsql: "bogus==value",
+      err: `unknown selector: "bogus"`,
+    },
+    {
+      rsql: "active==yes",
+      err: `bad selector value for "active": "yes" is not a boolean`,
+    },
+    {
+      rsql: "tier==DIAMOND",
+      err: `bad selector value for "tier": "DIAMOND" must be one of ["GOLD","SILVER","BRONZE"]`,
+    },
+    {
+      rsql: "points=gt=not-an-int",
+      err: 'bad selector value for "points": "not-an-int" is not a integer',
+    },
+    {
+      rsql: "birthday=gt=not-a-date;birthday<not-a-date",
+      err: 'bad selector value for "birthday": "not-a-date" is not a date',
+    },
+  ];
+  it.each(inputsForLaxUndefinedCase)("$rsql", ({ rsql, err }) => {
+    expect.hasAssertions();
+    const ast = parseRsql(rsql);
+    const actual = toSql(ast, {
+      ...TestQueryConfig,
+      values: [],
+      /* We have to trick typescript here. */
+      lax: undefined as unknown as true,
     });
     expect(actual).toStrictEqual({ isValid: false, err });
   });


### PR DESCRIPTION
- Fix [Optional "boolean" configuration options checked by key-in-object could resolve to true if the key is set to undefined](https://github.com/massfords/ts-rsql-query/issues/8).